### PR TITLE
Encrypt credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-roomba980-fw2",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Node to control a Roomba980(v2 firmware) robot via dorita980 API ",
 
   "keywords": [

--- a/roomba980/roomba980.html
+++ b/roomba980/roomba980.html
@@ -3,9 +3,11 @@
     category:'config',
     defaults: {
       ip: {value: '', required: true},
-      username: {value: '', required: true},
-      password: {value: '', required: true},
       name: {value: ''}
+    },
+    credentials: {
+      username: { type: 'text' },
+      password: { type: 'password' }
     },
     label: function(){
       return this.name || 'Roomba980';

--- a/roomba980/roomba980.js
+++ b/roomba980/roomba980.js
@@ -5,7 +5,7 @@ module.exports = function(RED) {
   function dorita980ConfigNode(n) {
     RED.nodes.createNode(this, n);
 
-      this.robot = new dorita980.Local(n.username, n.password, n.ip);
+      this.robot = new dorita980.Local(this.credentials.username, this.credentials.password, n.ip);
 
       this.on('close', function() {
           this.robot.end();
@@ -132,5 +132,10 @@ module.exports = function(RED) {
   RED.nodes.registerType("set", setMethodNode);
   RED.nodes.registerType("basic", basicNode);
 
-  RED.nodes.registerType('dorita980Config', dorita980ConfigNode);
+  RED.nodes.registerType('dorita980Config', dorita980ConfigNode, {
+    credentials: {
+      username: { type: 'text' },
+      password: { type: 'password' }
+    }
+  });
 }


### PR DESCRIPTION
As discussed in issue #3, with this PR credentials are now placed (and encrypted) inside `flows_cred.json` instead of being placed (unencrypted) inside `flows.json`. I am already using the exact same changes in a local copy of this code for some months in [one of my personal repos](https://github.com/IanStorm/my-smart-home-node-red); so far it works as expected. 🤞 
Not sure which way you prefer, I already bumped the bug fix version of the package. Depending on your preference I can remove that change, or bump major or minor version.
Thanks in advance for spending your precious time on this PR. Looking forward to seeing the changes in action. 🤜🤛 