### PR TITLE
dorita980 repo change for nodejs 16+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/yuchangyuan/node-red-contrib-roomba980-fw2"
   },
   "dependencies": {
-    "dorita980": ">=2.4.0"
+    "@karlvr/dorita980": "^3.2.0"
    },
   "node-red": {
     "nodes": {

--- a/roomba980/roomba980.js
+++ b/roomba980/roomba980.js
@@ -1,6 +1,6 @@
 module.exports = function(RED) {
 
-  var dorita980 = require('dorita980');
+  var dorita980 = require('@karlvr/dorita980');
 
   function dorita980ConfigNode(n) {
     RED.nodes.createNode(this, n);


### PR DESCRIPTION
I merge dorita980 dependency to karlvr/dorita980 to fix compatibility problem with nodejs 16+

It's work for me on this setup : 
Node-RED version: v4.1.4
Node.js  version: v20.20.0
Linux 6.12.47+rpt-rpi-v8 arm64 LE